### PR TITLE
chore: mention no traces by POST http action

### DIFF
--- a/codereview101/definitions.json
+++ b/codereview101/definitions.json
@@ -143,13 +143,13 @@
                 "questionId":"data.q2",
                 "lineToHighlight":2,
                 "language":"java",
-                "question":"Can you spot the code that transmits data securely??",
+                "question":"Can you spot the code that transmits data securely and with no traces?",
                 "snippets":[
                     "snipData3.java",
                     "snipData4.java"
                 ],
                 "answer":0,
-                "correctReasoning":"You're right! The code sample uses a 'https://' url to transmit data.",
+                "correctReasoning":"You're right! The code uses TLS 'https://' and sends data using POST, which doesn't store the parameters in web logs.",
                 "incorrectReasoning": "Incorrect! The code is sending a user name and a password via a 'http://' url."
             },
 

--- a/codereview101/definitions.json
+++ b/codereview101/definitions.json
@@ -150,7 +150,7 @@
                 ],
                 "answer":0,
                 "correctReasoning":"You're right! The code uses TLS 'https://' and sends data using POST, which doesn't store the parameters in web logs.",
-                "incorrectReasoning": "Incorrect! The code is sending a user name and a password via a 'http://' url."
+                "incorrectReasoning": "Incorrect! The code is sending a user name and a password via a 'http://' url and risks of storing the credentials in web logs."
             },
 
             {

--- a/codereview101/definitions.json
+++ b/codereview101/definitions.json
@@ -143,7 +143,7 @@
                 "questionId":"data.q2",
                 "lineToHighlight":2,
                 "language":"java",
-                "question":"Can you spot the code that transmits data securely and with no traces?",
+                "question":"Can you spot the code that transmits data securely?",
                 "snippets":[
                     "snipData3.java",
                     "snipData4.java"


### PR DESCRIPTION
**What was missing?**
The login form transmitting over TLS did not mention the usage of GET vs POST.
Added the POST correct usage and GET web logging.