### PR TITLE
Infrastructure creation using terragrunt

### DIFF
--- a/pipelines/deploy_infra.groovy
+++ b/pipelines/deploy_infra.groovy
@@ -1,0 +1,86 @@
+properties([
+  parameters([
+    choiceParam(name: 'TERRAGRUNT_ACTION', choices: "plan\napply", description: 'Terragrunt action'),
+    text(name: 'TERRAGRUNT_ROOTS', defaultValue: '''root-alb/sg\nroot-alb/s3\nroot-alb/alb\nroot-alb/route53\n''',
+    description: 'The folders that Terragrunt will traverse that exist under terraform/<env>')
+  ])
+])
+
+def tfNode = 'tf_node_secure-coding-dojo'
+
+node(tfNode){
+  try {
+    def environment = "prod"
+    def region = "us-east-2"
+    def versionTerraform = "0.12.24"
+    def versionTerragrunt = "v0.23.14"
+    def terragruntPath = "${WORKSPACE}/terraform"
+    def commands = []
+
+    stage("Checkout source"){
+      echo "Checkout source..."
+      checkout scm
+    } // stage
+
+    stage("Get secret vars from AWS SM") {
+      echo "Get additional vars (sensitive information) from secretsmanager..."
+      dir("${terragruntPath}/${environment}") {
+        sh "aws secretsmanager --region ${region} get-secret-value --secret-id 'terragrunt-${environment}-vars.yaml' --query SecretString --output text > vars_additional.yaml"
+        docker.image("mikefarah/yq").inside(){
+          sh "yq m -i vars.yaml vars_additional.yaml"
+        } // docker.image
+      } // dir
+    } // stage
+
+    stage("Construct terragrunt commands"){
+      params.TERRAGRUNT_ROOTS.split().each { item ->
+        def extra_args = ""
+        if ("${params.TERRAGRUNT_ACTION}" == 'plan') {
+          def outfilepath = "${item}.plan".replace('/','_')
+          extra_args = "-out=${terragruntPath}/${outfilepath}.output -detailed-exitcode"
+        }
+        else if ("${params.TERRAGRUNT_ACTION}" == 'apply') {
+          // terragrunt apply with --terragrunt-non-interactive does not pass the below extra args to the underlying terraform by default.
+          extra_args = "-input=false -auto-approve"
+        } // if
+        commands.add("terragrunt ${params.TERRAGRUNT_ACTION} --terragrunt-working-dir ${terragruntPath}/${environment}/${item} --terragrunt-non-interactive ${extra_args}")
+      } // params.each
+    } // stage
+
+    stage("Do terragrunt action"){
+      docker.image("alpine/terragrunt:${versionTerraform}").inside("-u 0"){
+        sh "wget -q https://github.com/gruntwork-io/terragrunt/releases/download/${versionTerragrunt}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt"
+        commands.each { command ->
+          sh "echo Command: ${command}"
+          wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'xterm']) {
+            def status = sh(returnStatus: true, script: "${command}")
+            if (status == 0) {
+              echo "Command ran successfully."
+            }
+            // Status of 2 indicates non-empty diff [Ref: https://www.terraform.io/docs/commands/plan.html]
+            else if (status == 2 && params.TERRAGRUNT_ACTION == 'plan') {
+              echo "Drift detected."
+              // Get filename of the terraform output and replace ''.output' to '.drift'
+              def driftfilepath = command.split().find{ it =~ '-out=' }.split('=')[-1].split('/')[-1].replace('.output','.drift')
+              writeFile(file:"${driftfilepath}", text:'true')
+            }
+            else {
+              throw "Action ${params.TERRAGRUNT_ACTION} failed with status ${status}"
+            } // if
+          } // wrap
+        } // commands.each
+      } // docker.image
+    } // stage
+
+    stage ('Archive artifacts'){
+      if (params.TERRAGRUNT_ACTION == 'plan') {
+        sh "find ${terragruntPath} -name '*.output' -exec cp {} ${WORKSPACE} \\;"
+        archiveArtifacts "*.output,*.drift"
+      } // end of scriptedWhen
+    } // end of stage
+  } // try
+  finally {
+    sh "sudo find . -type d -name '.terragrunt-cache' -prune -exec rm -rf {} \\;"
+    deleteDir()
+  } // finally
+} // node

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,45 @@
+# IaC (Infrastructure as Code)
+Infrastucture deployment is done using Terragrunt (wrapper for Terraform)
+
+## Prerequisites
+### Tools
+The following tools needs to be installed before proceeding to the next step.
+1. Terragrunt - [0.23.14](https://github.com/gruntwork-io/terragrunt/releases/download/v0.23.14/terragrunt_linux_amd64)
+2. Terraform - [0.12.24](https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip)
+
+### Config
+Some sensitive information is removed from the config (input) file provided to terragrunt. Add the required information to `terraform/<env>/vars.yaml`, namely
+  ```
+  global:
+    awsAccountId: <account_id>
+    vpc: <vpc_id>
+    subnetIds:
+      public:
+        - <subnet_id1>
+        - <subnet_id2>
+        - <subnet_id3>
+    certArn: <cert_arn>
+  rootAlb:
+    route53:
+      parentZoneName: <parent_zone_name>
+  ```
+
+## Run
+Execute a terragrunt apply which generates a plan which the user can review. This interactive command would then ask for confirmation to proceed before applying changes.
+
+Since one module depends on the other, infrastructure creation as per the following sequence is necessary.
+   ```
+   cd terraform/<env>
+   terragrunt apply --terragrunt-working-dir root-alb/sg
+   terragrunt apply --terragrunt-working-dir root-alb/s3
+   terragrunt apply --terragrunt-working-dir root-alb/alb
+   terragrunt apply --terragrunt-working-dir root-alb/route53
+   ```
+
+## Other information
+The current 3rd party terraform module for AWS ALB does not support adding LB listener rules.
+And so, the path based routing for `/redblueapp` was added manually.
+
+The access logs are also saved to an S3 bucket, again created using terraform.
+
+Adding to route53 is based on an enabled flag. If enabled, it would add two aliases for your parent zone name. This parent zone name needs to be updated from within vars.yml

--- a/terraform/prod/root-alb/alb/backend.tf
+++ b/terraform/prod/root-alb/alb/backend.tf
@@ -1,0 +1,15 @@
+terraform {
+  # Intentionally empty. Will be filled by Terragrunt.
+  backend "s3" {}
+}
+
+variable "aws_region" {
+  description = ""
+}
+
+provider "aws" {
+  #user should already be connected with jenkins credentials
+  #only the region should be provided
+  region  = var.aws_region
+  version = "~> 2.0"
+}

--- a/terraform/prod/root-alb/alb/terragrunt.hcl
+++ b/terraform/prod/root-alb/alb/terragrunt.hcl
@@ -1,0 +1,108 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+
+locals {
+  vars = yamldecode(file("${find_in_parent_folders("vars.yaml")}"))
+
+  # Global vars
+  global_vars_region       = local.vars.global.region
+  global_vars_environment  = local.vars.global.environment
+  global_vars_awsAccountId = local.vars.global.awsAccountId
+  global_vars_vpc          = local.vars.global.vpc
+  global_vars_subnetIds    = local.vars.global.subnetIds
+  global_vars_certArn      = local.vars.global.certArn
+  global_vars_tags         = local.vars.global.tags
+
+  # Internal API ALB specific vars
+  vars_namePrefix         = local.vars.rootAlb.namePrefix
+  vars_s3BucketPrefix     = local.vars.rootAlb.s3BucketPrefix
+  vars_deletionProtection = lookup(local.vars.rootAlb, "deletionProtection", false)
+  vars_vpc                = lookup(local.vars.rootAlb, "vpc", local.global_vars_vpc)
+  vars_subnetIds          = lookup(local.vars.rootAlb, "subnetIds", local.global_vars_subnetIds.public)
+  vars_tags               = lookup(local.vars.rootAlb, "tags", local.global_vars_tags)
+  vars_certArn            = replace(lookup(local.vars.rootAlb, "certArn", local.global_vars_certArn), "[-awsAccountId-]", local.global_vars_awsAccountId)
+}
+
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-alb?ref=v5.4.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependencies {
+  paths = ["../s3", "../sg"]
+}
+
+dependency "s3" {
+  config_path = "../s3"
+
+  mock_outputs = {
+    this_s3_bucket_id = "this_s3_bucket_id"
+  }
+  mock_outputs_allowed_terraform_commands = ["plan"]
+}
+
+dependency "sg" {
+  config_path = "../sg"
+
+  mock_outputs = {
+    this_security_group_id = "this_security_group_id"
+  }
+  mock_outputs_allowed_terraform_commands = ["plan"]
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name    = "${local.vars_namePrefix}-${local.global_vars_environment}-ALB"
+  region  = local.global_vars_region
+  vpc_id  = local.vars_vpc
+  subnets = local.vars_subnetIds
+
+  access_logs = {
+    bucket = dependency.s3.outputs.this_s3_bucket_id
+  }
+
+  target_groups = [
+    {
+      name             = "${local.vars_namePrefix}-${local.global_vars_environment}-ALB-insecureinc-TG"
+      backend_protocol = "HTTP"
+      backend_port     = 80
+      target_type      = "ip"
+    },
+    {
+      name             = "${local.vars_namePrefix}-${local.global_vars_environment}-ALB-redblueapp-TG"
+      backend_protocol = "HTTP"
+      backend_port     = 8080
+      target_type      = "ip"
+    }
+  ]
+
+  https_listeners = [
+    {
+      port               = 443
+      protocol           = "HTTPS"
+      certificate_arn    = local.vars_certArn
+      ssl_policy         = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      target_group_index = 0
+    }
+  ]
+
+  http_tcp_listeners = [
+    {
+      port        = 80
+      protocol    = "HTTP"
+      action_type = "redirect"
+      redirect = {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  ]
+  security_groups            = [dependency.sg.outputs.this_security_group_id]
+  enable_deletion_protection = local.vars_deletionProtection
+  tags                       = local.vars_tags
+}

--- a/terraform/prod/root-alb/route53/backend.tf
+++ b/terraform/prod/root-alb/route53/backend.tf
@@ -1,0 +1,15 @@
+terraform {
+  # Intentionally empty. Will be filled by Terragrunt.
+  backend "s3" {}
+}
+
+variable "aws_region" {
+  description = ""
+}
+
+provider "aws" {
+  #user should already be connected with jenkins credentials
+  #only the region should be provided
+  region  = var.aws_region
+  version = "~> 2.0"
+}

--- a/terraform/prod/root-alb/route53/terragrunt.hcl
+++ b/terraform/prod/root-alb/route53/terragrunt.hcl
@@ -1,0 +1,47 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+
+locals {
+  vars = yamldecode(file("${find_in_parent_folders("vars.yaml")}"))
+
+  # Global vars
+  global_vars_region = local.vars.global.region
+
+  # Route53 specific vars
+  vars_route53                = lookup(local.vars.rootAlb, "route53", {})
+  vars_route53_enabled        = lookup(local.vars_route53, "enabled", true)
+  vars_route53_aliases        = lookup(local.vars_route53, "aliases", [])
+  vars_route53_parentZoneName = lookup(local.vars_route53, "parentZoneName", "")
+}
+
+terraform {
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-alias?ref=0.6.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+dependencies {
+  paths = ["../alb"]
+}
+
+dependency "alb" {
+  config_path = "../alb"
+
+  mock_outputs = {
+    this_lb_zone_id  = "this_lb_zone_id"
+    this_lb_dns_name = "this_lb_dns_name"
+  }
+  mock_outputs_allowed_terraform_commands = ["plan"]
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  enabled          = local.vars_route53_enabled
+  aliases          = local.vars_route53_aliases
+  parent_zone_name = local.vars_route53_parentZoneName
+  target_zone_id   = dependency.alb.outputs.this_lb_zone_id
+  target_dns_name  = dependency.alb.outputs.this_lb_dns_name
+}

--- a/terraform/prod/root-alb/s3/backend.tf
+++ b/terraform/prod/root-alb/s3/backend.tf
@@ -1,0 +1,15 @@
+terraform {
+  # Intentionally empty. Will be filled by Terragrunt.
+  backend "s3" {}
+}
+
+variable "aws_region" {
+  description = ""
+}
+
+provider "aws" {
+  #user should already be connected with jenkins credentials
+  #only the region should be provided
+  region  = var.aws_region
+  version = "~> 2.0"
+}

--- a/terraform/prod/root-alb/s3/terragrunt.hcl
+++ b/terraform/prod/root-alb/s3/terragrunt.hcl
@@ -1,0 +1,31 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+
+locals {
+  vars = yamldecode(file("${find_in_parent_folders("vars.yaml")}"))
+
+  # Global vars
+  global_vars_awsAccountId = local.vars.global.awsAccountId
+  global_vars_tags         = local.vars.global.tags
+
+  # Local vars
+  vars_s3BucketPrefix = local.vars.rootAlb.s3BucketPrefix
+  vars_tags           = lookup(local.vars.rootAlb, "tags", local.global_vars_tags)
+}
+
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket?ref=v1.6.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  bucket                         = "${local.vars_s3BucketPrefix}-${local.global_vars_awsAccountId}"
+  acl                            = "log-delivery-write"
+  attach_elb_log_delivery_policy = true
+  tags                           = local.vars_tags
+}

--- a/terraform/prod/root-alb/sg/backend.tf
+++ b/terraform/prod/root-alb/sg/backend.tf
@@ -1,0 +1,15 @@
+terraform {
+  # Intentionally empty. Will be filled by Terragrunt.
+  backend "s3" {}
+}
+
+variable "aws_region" {
+  description = ""
+}
+
+provider "aws" {
+  #user should already be connected with jenkins credentials
+  #only the region should be provided
+  region  = var.aws_region
+  version = "~> 2.0"
+}

--- a/terraform/prod/root-alb/sg/terragrunt.hcl
+++ b/terraform/prod/root-alb/sg/terragrunt.hcl
@@ -1,0 +1,37 @@
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+
+locals {
+  vars = yamldecode(file("${find_in_parent_folders("vars.yaml")}"))
+
+  # Global vars
+  global_vars_environment  = local.vars.global.environment
+  global_vars_awsAccountId = local.vars.global.awsAccountId
+  global_vars_vpc          = local.vars.global.vpc
+  global_vars_tags         = local.vars.global.tags
+
+  # Local vars
+  vars_namePrefix = local.vars.rootAlb.namePrefix
+  vars_vpc        = lookup(local.vars.rootAlb, "vpc", local.global_vars_vpc)
+  vars_tags       = lookup(local.vars.rootAlb, "tags", local.global_vars_tags)
+}
+
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group?ref=v3.8.0"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+inputs = {
+  name                = "${local.vars_namePrefix}-${local.global_vars_environment}-ALB-SG"
+  description         = "SG for ${local.vars_namePrefix}-${local.global_vars_environment}-ALB"
+  vpc_id              = local.vars_vpc
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+  ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+  egress_rules        = ["all-all"]
+  tags                = local.vars_tags
+}

--- a/terraform/prod/terragrunt.hcl
+++ b/terraform/prod/terragrunt.hcl
@@ -1,0 +1,24 @@
+# Configure Terragrunt to automatically store tfstate files in an S3 bucket
+locals {
+  vars = yamldecode(file("vars.yaml"))
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = join("-", ["terraform-states", local.vars.global.region, local.vars.global.awsAccountId])
+    key            = join("/", [local.vars.global.environment, path_relative_to_include(), "terraform.tfstate"])
+    region         = local.vars.global.region
+    dynamodb_table = "terraform-locks" # shared within a region
+  }
+}
+
+# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
+# where terraform_remote_state data sources are placed directly into the modules.
+inputs = {
+  aws_region                   = local.vars.global.region
+  tfstate_global_bucket        = join("-", ["terraform-states", local.vars.global.region, local.vars.global.awsAccountId])
+  tfstate_global_bucket_region = local.vars.global.region
+}

--- a/terraform/prod/vars.yaml
+++ b/terraform/prod/vars.yaml
@@ -1,0 +1,26 @@
+# *m* = Mandatory. Also these need to be defined as local vars without the lookup function in the terragrunt hcl file
+# *p* = If defined, takes precedence over the corresponding global var
+# *sm* - Mandatory and populated from the secretsmanager during buildtime.
+# See eks terragrunt hcl file for more info
+global: # *m*
+  region: us-east-2 # *m*
+  environment: prod # *m*
+  awsAccountId: # *sm*
+  vpc: # *sm*
+  subnetIds: # *sm*
+    public: # *sm*
+    private:
+    privateWithInternet:
+  certArn: # *sm*
+  tags: # *m*
+    ManagedBy: Terragrunt # *m*
+rootAlb:
+  namePrefix: SCDRoot # *m*
+  s3BucketPrefix: logs-lb # *m*
+  deletionProtection: true
+  route53:
+    enabled: true
+    aliases:
+    - .
+    - www
+    parentZoneName: # *sm*


### PR DESCRIPTION
Left out sensitive information such as -
* AWS Account ID
* VPC ID
* Subnet IDs
* Cert ARN
* Route53 parent zone name

The current 3rd party terraform module for AWS ALB does not support adding LB listener rules.
And so, the path based routing for `/redblueapp` was added manually.

The access logs are also saved to an S3 bucket, again created using terraform.

Adding to route53 is based on an enabled flag. If enabled, it would add an ALIAS for `insecure.link` and `www.insecure.link` pointing to the LB that was created. Ofcourse the zone/domain is update can also be changed from within vars.yml

The README.md under the terraform folder has more information on the tools used and how to create this infrastructure using terragrunt.