### PR TITLE
added copyright requirements from legal to allow transition to owasp

### DIFF
--- a/codereview101/snipData1.java
+++ b/codereview101/snipData1.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String usr = request.getParameter("usr");
 String pwd = request.getParameter("pwd");

--- a/codereview101/snipData2.java
+++ b/codereview101/snipData2.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String usr = request.getParameter("usr");
 String pwd = request.getParameter("pwd");

--- a/codereview101/snipData3.java
+++ b/codereview101/snipData3.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String url = "https://my-service.cloud.biz/Login";
 URL obj = new URL(url);

--- a/codereview101/snipData4.java
+++ b/codereview101/snipData4.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String url = "http://my-service.cloud.biz/Login?usr="+usr+"&pwd="+pwd;
 URL obj = new URL(url);

--- a/codereview101/snipIndirectReferences1.java
+++ b/codereview101/snipIndirectReferences1.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String file = request.getParameter("file");
 file = "public/"+file;

--- a/codereview101/snipIndirectReferences2.java
+++ b/codereview101/snipIndirectReferences2.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String fileId = request.getParameter("fileId");
 file = "public/"+availableFiles[fileId];

--- a/codereview101/snipIndirectReferences3.java
+++ b/codereview101/snipIndirectReferences3.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String ssoUrl = request.getParameter("authProviderUrl");
 

--- a/codereview101/snipIndirectReferences4.java
+++ b/codereview101/snipIndirectReferences4.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String authProviderId = request.getParameter("authProviderId");
 URL ssoUrl = registeredAuthProviders[authProviderId].getUrl();

--- a/codereview101/snipInputValidation1.java
+++ b/codereview101/snipInputValidation1.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String updateServer = request.getParameter("updateServer");
 if(updateServer.indexOf(";")==-1 && updateServer.indexOf("&")==-1){

--- a/codereview101/snipInputValidation2.java
+++ b/codereview101/snipInputValidation2.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String updateServer = request.getParameter("updateServer");
 if(ValidationUtils.isAlphanumericOrAllowed(updateServer,'-','_','.')){

--- a/codereview101/snipParamStatements1.java
+++ b/codereview101/snipParamStatements1.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String updateServer = request.getParameter("updateServer");
 List<String> commandArgs = new ArrayList<String>();

--- a/codereview101/snipParamStatements2.java
+++ b/codereview101/snipParamStatements2.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String updateServer = request.getParameter("updateServer");
 String cmdProcessor = Utils.isWindows() ? "cmd" : "/bin/sh";

--- a/codereview101/snipParamStatements3.java
+++ b/codereview101/snipParamStatements3.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String query = String.format("SELECT * FROM users WHERE usr='%s' AND pwd='%s'", usr, pwd);
 Connection conn = db.getConn();

--- a/codereview101/snipParamStatements4.java
+++ b/codereview101/snipParamStatements4.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 
 String query = "SELECT * FROM users WHERE usr = ? AND pwd = ?";
 Connection conn = db.getConn();

--- a/hackerden/commandproc/src/serial/Cat.java
+++ b/hackerden/commandproc/src/serial/Cat.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.Serializable;

--- a/hackerden/commandproc/src/serial/Command.java
+++ b/hackerden/commandproc/src/serial/Command.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.Serializable;

--- a/hackerden/commandproc/src/serial/CommandType.java
+++ b/hackerden/commandproc/src/serial/CommandType.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 public enum CommandType {

--- a/hackerden/commandproc/src/serial/GetCommand.java
+++ b/hackerden/commandproc/src/serial/GetCommand.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.ByteArrayOutputStream;

--- a/hackerden/commandproc/src/serial/LoginDocument.java
+++ b/hackerden/commandproc/src/serial/LoginDocument.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.File;

--- a/hackerden/commandproc/src/serial/SubmitCommand.java
+++ b/hackerden/commandproc/src/serial/SubmitCommand.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 

--- a/insecureinc/src/inc/insecure/Ch1Loggedin.java
+++ b/insecureinc/src/inc/insecure/Ch1Loggedin.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/Constants.java
+++ b/insecureinc/src/inc/insecure/Constants.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 /**

--- a/insecureinc/src/inc/insecure/Crypto.java
+++ b/insecureinc/src/inc/insecure/Crypto.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/Cwe434FileUpload.java
+++ b/insecureinc/src/inc/insecure/Cwe434FileUpload.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/GetCode.java
+++ b/insecureinc/src/inc/insecure/GetCode.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/SetUnlockCode.java
+++ b/insecureinc/src/inc/insecure/SetUnlockCode.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/UnlockCodeFilter.java
+++ b/insecureinc/src/inc/insecure/UnlockCodeFilter.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.IOException;

--- a/insecureinc/src/inc/insecure/Util.java
+++ b/insecureinc/src/inc/insecure/Util.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package inc.insecure;
 
 import java.io.BufferedReader;

--- a/insecureinc/src/serial/Cat.java
+++ b/insecureinc/src/serial/Cat.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.Serializable;

--- a/insecureinc/src/serial/SubmitObject.java
+++ b/insecureinc/src/serial/SubmitObject.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 

--- a/serialcat/src/serial/Cat.java
+++ b/serialcat/src/serial/Cat.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 import java.io.Serializable;

--- a/serialcat/src/serial/SubmitObject.java
+++ b/serialcat/src/serial/SubmitObject.java
@@ -1,3 +1,9 @@
+/*
+Copyright 2017-2018 Trend Micro Incorporated
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License at
+https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
 package serial;
 
 


### PR DESCRIPTION
Per legal's request, I added an individual copyright notice to each of the code files in the repository before transfer as well as a copyright notice and a note about Trend Micro Incorporated in the readme.

Once this PR is merged, a member of the Trend git organization will invite Harold  "hblankenship" - https://github.com/hblankenship  as a repository administrator and at that point he will make the transfer from the Trend Micro Organization to the OWASP Organization.

